### PR TITLE
chore: update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains Nix package definitions for various tools and utilities
 | aftman | 0.3.0 | Aftman is a command line toolchain manager | [https://github.com/LPGhatguy/aftman](https://github.com/LPGhatguy/aftman) |
 | argon | 2.0.26 | Fully featured tool for Roblox development | [https://github.com/argon-rbx/argon](https://github.com/argon-rbx/argon) |
 | asphalt | 1.2.0 | Upload and reference Roblox assets in code | [https://github.com/jackTabsCode/asphalt](https://github.com/jackTabsCode/asphalt) |
-| darklua | 0.17.2 | A command line tool that transforms Lua 5.1 and Roblox Lua scripts using rules | [https://github.com/seaofvoices/darklua](https://github.com/seaofvoices/darklua) |
+| darklua | 0.17.3 | A command line tool that transforms Lua 5.1 and Roblox Lua scripts using rules | [https://github.com/seaofvoices/darklua](https://github.com/seaofvoices/darklua) |
 | lune | 0.10.4 | A standalone Luau runtime | [https://github.com/lune-org/lune](https://github.com/lune-org/lune) |
 | mantle | 0.11.18 | An infrastructure-as-code and deployment tool for Roblox | [https://github.com/blake-mealey/mantle](https://github.com/blake-mealey/mantle) |
 | moonwave | 1.3.0 | Moonwave is a tool for generating documentation from comments in Lua source code. | [https://github.com/evaera/moonwave](https://github.com/evaera/moonwave) |

--- a/pkgs/darklua.nix
+++ b/pkgs/darklua.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "darklua";
-  version = "0.17.2";
+  version = "0.17.3";
 
   src = fetchFromGitHub {
     owner = "seaofvoices";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-RNm2d0VeLgHEawvZQYUcXesNwLc2m9Q6R6kNZhZDslg=";
+    sha256 = "sha256-IpTTNt/AlaDRckWq1Ck0A822rAtzeOt9RcB2F7CI5ig=";
   };
 
-  cargoHash = "sha256-WfXIMuqO1KTiWeqMOnsylNlJKv1cKNZvp8qhalPlcnc=";
+  cargoHash = "sha256-0TtABG+MSz3wdxhLgTZCFVgN8KwcDkVTwn+sZV+abbE=";
 
   passthru.updateScript = nix-update-script {};
 


### PR DESCRIPTION
Automated changes by the nix-update GitHub Action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `darklua` to 0.17.3, updating source and cargo hashes and reflecting the new version in the README.
> 
> - **Packages**:
>   - Update `pkgs/darklua.nix`:
>     - Bump `version` from `0.17.2` to `0.17.3`.
>     - Refresh `sha256` and `cargoHash`.
> - **Docs**:
>   - Update `README.md` package table to show `darklua` `0.17.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edbcf7d039214a571475fea8625dce6c3e38f9f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->