### PR TITLE
chore: update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Nix package definitions for various tools and utilities
 | Package Name | Version | Description | Homepage |
 |--------------|---------|-------------|----------|
 | aftman | 0.3.0 | Aftman is a command line toolchain manager | [https://github.com/LPGhatguy/aftman](https://github.com/LPGhatguy/aftman) |
-| argon | 2.0.26 | Fully featured tool for Roblox development | [https://github.com/argon-rbx/argon](https://github.com/argon-rbx/argon) |
+| argon | 2.0.27 | Fully featured tool for Roblox development | [https://github.com/argon-rbx/argon](https://github.com/argon-rbx/argon) |
 | asphalt | 1.2.0 | Upload and reference Roblox assets in code | [https://github.com/jackTabsCode/asphalt](https://github.com/jackTabsCode/asphalt) |
 | darklua | 0.17.3 | A command line tool that transforms Lua 5.1 and Roblox Lua scripts using rules | [https://github.com/seaofvoices/darklua](https://github.com/seaofvoices/darklua) |
 | lune | 0.10.4 | A standalone Luau runtime | [https://github.com/lune-org/lune](https://github.com/lune-org/lune) |

--- a/pkgs/argon.nix
+++ b/pkgs/argon.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "argon";
-  version = "2.0.26";
+  version = "2.0.27";
 
   src = fetchFromGitHub {
     owner = "argon-rbx";
     repo = pname;
     rev = "${version}";
-    sha256 = "sha256-3IftPWrBETU7zJLaB9uTrc08c37XGmFPPArzrlIFG3Q=";
+    sha256 = "sha256-AcgaY7XmecqvWan81tVxV6UJ+A38tAYDlvUSLLKlYuU=";
   };
 
-  cargoHash = "sha256-60BQ7PsKATq5jX5DqCGdOx3xvRzwm5TAM1RtKuPy49M=";
+  cargoHash = "sha256-0VIPAcCK7+te7TgH/+x0Y7pP0fYWuRT58/h9OIva0mQ=";
   passthru.updateScript = nix-update-script {};
   doCheck = false;
 


### PR DESCRIPTION
Automated changes by the nix-update GitHub Action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `argon` package to 2.0.27, refreshing source/cargo hashes and README version.
> 
> - **Packages**:
>   - Bump `argon` to `2.0.27` in `pkgs/argon.nix`.
>     - Update `sha256` and `cargoHash`.
> - **Docs**:
>   - Reflect new `argon` version in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e34c3e8f9ae27941eb9c05d827682023d4d9b71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->