### PR TITLE
chore: update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains Nix package definitions for various tools and utilities
 | mantle | 0.11.18 | An infrastructure-as-code and deployment tool for Roblox | [https://github.com/blake-mealey/mantle](https://github.com/blake-mealey/mantle) |
 | moonwave | 1.3.0 | Moonwave is a tool for generating documentation from comments in Lua source code. | [https://github.com/evaera/moonwave](https://github.com/evaera/moonwave) |
 | p | 1.4.0 | A simple project management tool for the command line written in Rust | [https://github.com/RevisionOrg/p](https://github.com/RevisionOrg/p) |
-| pesde | 0.7.1+registry.0.2.3 | A package manager for the Luau programming language, supporting multiple runtimes including Roblox and Lune | [https://github.com/pesde-pkg/pesde](https://github.com/pesde-pkg/pesde) |
+| pesde | 0.7.2+registry.0.2.3 | A package manager for the Luau programming language, supporting multiple runtimes including Roblox and Lune | [https://github.com/pesde-pkg/pesde](https://github.com/pesde-pkg/pesde) |
 | rbxcloud | 0.17.0 | CLI and library for the Roblox Open Cloud API | [https://github.com/Sleitnick/rbxcloud](https://github.com/Sleitnick/rbxcloud) |
 | roblox-rs | 0.0.1 | Rust bindings for the Roblox standard library (CLI) | [https://github.com/roblox-rs/roblox-rs](https://github.com/roblox-rs/roblox-rs) |
 | rojo | 7.6.1 | Enables professional-grade development tools for Roblox developers | [https://rojo.space](https://rojo.space) |

--- a/pkgs/pesde.nix
+++ b/pkgs/pesde.nix
@@ -9,16 +9,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "pesde";
-  version = "0.7.1+registry.0.2.3";
+  version = "0.7.2+registry.0.2.3";
 
   src = fetchFromGitHub {
     owner = "pesde-pkg";
     repo = pname;
-    rev = "v0.7.1+registry.0.2.3";
-    sha256 = "sha256-ad9ZDC7p2dsHEQHJltgBTgmy8Ew1tXk13isTDSumkZ4=";
+    rev = "v0.7.2+registry.0.2.3";
+    sha256 = "sha256-AZR9B4eMdPU4Ve1cCLCIEZvdjoP4HFnng4NcfA4NDhs=";
   };
 
-  cargoHash = "sha256-sdPGuEsdBt0TeEr7yqr5tROETLy/VG63n5+ulW72wzg=";
+  cargoHash = "sha256-1HcQdQqMcpePlO1WzPY4li+Kei9VDN4jfewPyAEDAWw=";
 
   cargoBuildFlags = ["--features" "bin"];
 


### PR DESCRIPTION
Automated changes by the nix-update GitHub Action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the pesde package and docs.
> 
> - Bumps `pesde` in `pkgs/pesde.nix` to `v0.7.2+registry.0.2.3`, updating `rev`, `sha256`, and `cargoHash`
> - Syncs `README.md` package table to the new `pesde` version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be2ff4d22cfb19e524f62b5d6736f0a4b0f141d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->